### PR TITLE
Add `Routes` builder for tower integration

### DIFF
--- a/axum-connect-examples/src/main.rs
+++ b/axum-connect-examples/src/main.rs
@@ -5,7 +5,6 @@
 //!
 
 use async_stream::stream;
-use axum::Router;
 use axum_connect::{futures::Stream, prelude::*};
 use axum_extra::extract::Host;
 use error::Error;
@@ -29,16 +28,15 @@ mod proto {
 
 #[tokio::main]
 async fn main() {
-    // Build our application with a route. Note the `rpc` method which was added by `axum-connect`.
-    // It expect a service method handler, wrapped in it's respective type. The handler (below) is
-    // just a normal Rust function. Just like Axum, it also supports extractors!
-    let app = Router::new()
+    // Build our application using the `Routes` builder which mirrors Tonic's API.
+    let app = Routes::new()
         // A standard unary (POST based) Connect-Web request handler.
-        .rpc(HelloWorldService::say_hello(say_hello_unary))
+        .add_service(HelloWorldService::say_hello(say_hello_unary))
         // A GET version of the same thing, which has well-defined semantics for caching.
-        .rpc(HelloWorldService::say_hello_unary_get(say_hello_unary))
+        .add_service(HelloWorldService::say_hello_unary_get(say_hello_unary))
         // A server-streaming request handler. Very useful when you need them!
-        .rpc(HelloWorldService::say_hello_stream(stream_three_reponses));
+        .add_service(HelloWorldService::say_hello_stream(stream_three_reponses))
+        .into_router();
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:3030")
         .await

--- a/axum-connect/src/lib.rs
+++ b/axum-connect/src/lib.rs
@@ -3,6 +3,7 @@ pub mod handler;
 pub mod parts;
 pub mod response;
 pub mod router;
+pub mod routes;
 
 // Re-export several crates
 pub use futures;
@@ -16,4 +17,5 @@ pub mod prelude {
     pub use crate::parts::*;
     pub use crate::response::*;
     pub use crate::router::RpcRouterExt;
+    pub use crate::routes::Routes;
 }

--- a/axum-connect/src/routes.rs
+++ b/axum-connect/src/routes.rs
@@ -1,0 +1,44 @@
+use axum::Router;
+
+/// Builder for composing Connect RPC services using an API similar to
+/// `tonic`'s [`Routes`].
+#[derive(Clone, Debug)]
+pub struct Routes<S = ()> {
+    router: Router<S>,
+}
+
+impl<S> Routes<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    /// Create an empty [`Routes`].
+    pub fn new() -> Self {
+        Self { router: Router::new() }
+    }
+
+    /// Create an empty [`Routes`] with the given state.
+    pub fn with_state(state: S) -> Self {
+        Self {
+            router: Router::new().with_state(state),
+        }
+    }
+
+    /// Add a generated Connect service to this builder.
+    pub fn add_service<F>(mut self, svc: F) -> Self
+    where
+        F: FnOnce(Router<S>) -> crate::router::RpcRouter<S>,
+    {
+        self.router = svc(self.router);
+        Self { router: self.router }
+    }
+
+    /// Convert this builder into an [`axum::Router`].
+    pub fn into_router(self) -> Router<S> {
+        self.router
+    }
+
+    /// Convert this builder directly into a [`tower::Service`].
+    pub fn into_service<B>(self) -> axum::routing::RouterIntoService<B, S> {
+        self.router.into_service()
+    }
+}


### PR DESCRIPTION
## Summary
- add a `Routes` builder that mimics Tonic's API
- re-export `Routes` in the prelude
- update README and example to use the new builder

## Testing
- `cargo check --workspace`
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_684b9fdb31a8832e9fde2bc69fc2c2a8